### PR TITLE
Fix logical condition for memory checks

### DIFF
--- a/easycheck.sh
+++ b/easycheck.sh
@@ -176,7 +176,7 @@ function CheckMemory() {
   then
     GreenColor " - for large installation "; OkMark
   else
-    if [ "$MEMORY" -le "$OKMEM" ]
+    if [ "$MEMORY" -ge "$OKMEM" ]
     then
       BlueColor " - for small installation"; OkMark
     else


### PR DESCRIPTION
The screenshot also displays wrong behavior - 5Gb is more than 4Gb, which is supposed to be enough for small installations